### PR TITLE
Feat/eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,4 +169,10 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Library specifics
 poetry.lock
+*.json
+*.txt
+*safetensors
+*results*

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Key features:
 - **Task-agnostic distillation**: Compress models without task-specific fine-tuning (task-specific distillation planned for future releases)
 - **Flexible architecture**: Compress models to different sizes by configuring layers and dimensions
 - **Teacher weight inheritance**: Option to initialize student with teacher weights for better performance
-- **Multi-head self-attention relation distillation**: Transfer knowledge using fine-grained self-attention relations
-- **Multiple relation heads**: More relation heads provide more granular knowledge transfer
 - **Support for various teacher models**: Compatible with BERT-based architectures
 
 ## Installation
@@ -34,6 +32,10 @@ pip install -e .
 ```
 
 ## Quick Start
+
+### Complete Example
+
+See the [examples/minilm_distillation.py](examples/minilm_distillation.py) file for a complete distillation example.
 
 ### Preparing Datasets
 
@@ -141,7 +143,7 @@ The implementation supports three primary relation types:
 
 ### Teacher Weight Inheritance
 
-BertDistiller supports initializing the student model with the teacher's weights, which can improve distillation performance. The `create_student` function intelligently handles weight transfer, including cases where the student has different hidden dimensions and fewer layers than the teacher.
+BertDistiller supports initializing the student model with the teacher's weights, which can improve distillation performance. The `create_student` function handles weight transfer, including cases where the student has different hidden dimensions and fewer layers than the teacher.
 
 ## Configuration Options
 
@@ -157,10 +159,6 @@ This class extends Hugging Face's `TrainingArguments` with MiniLMv2-specific par
 | `student_attention_heads` | Number of attention heads in the student model |
 | `num_relation_heads` | Number of relation heads for distillation (more heads = more fine-grained knowledge) |
 | `relations` | Dictionary mapping relation types to weights, e.g., `{(1,1): 1.0}` for Q-Q relation |
-
-## Complete Example
-
-See the [examples/minilm_distillation.py](examples/minilm_distillation.py) file for a complete distillation example.
 
 ## Evaluation
 

--- a/README.md
+++ b/README.md
@@ -171,22 +171,20 @@ from bertdistiller.evaluation import evaluate
 
 # Evaluate a model on all GLUE tasks with different hyperparameters
 evaluate(
-    model_name_or_path="./bert-base-uncased-L6-H384",
+    model_name_or_path="microsoft/MiniLM-L12-H384-uncased", # or path to your distilled model
     tasks=["mnli", "qnli", "qqp", "rte", "sst2", "mrpc", "cola", "stsb"],
     learning_rate=[1e-5, 2e-5, 3e-5],
     epochs=[3, 5, 10],
-    output_dir="./evaluation_results",
 )
 
 # Evaluate on specific tasks with custom parameters
 evaluate(
     model_name_or_path="microsoft/MiniLM-L12-H384-uncased",
     tasks=["sst2", "mrpc"],  # Subset of tasks
-    learning_rate=[3e-5],    # Specific learning rate
-    epochs=[3],              # Specific number of epochs
+    learning_rate=3e-5,    # Specific learning rate
+    epochs=3,              # Specific number of epochs
     per_device_train_batch_size=16,
     cache_dir=".cache",
-    show_live_output=True,   # See training progress in real-time
 )
 ```
 The evaluation utility:
@@ -207,7 +205,27 @@ evaluation_results/
     │   └── ...
     └── ...
 ```
-This comprehensive evaluation helps compare the performance of distilled models against their teacher models and other baselines.
+This evaluation helps compare the performance of distilled models against other models or their teacher models.
+
+### Create Evaluation Summary
+After running evaluations, you can generate a summary table to easily compare model performance across tasks:
+```python
+from bertdistiller.evaluation import create_summary_table
+
+# Create summary table from evaluation results
+summary = create_summary_table(
+    results_dir="./evaluation_results",
+    save=True,
+    include_average=True,
+)
+
+print(summary)
+```
+The summary table displays the best scores for each model across all tasks, showing:
+- Model names as rows
+- GLUE tasks as columns
+- Optional "Avg" column with mean performance across tasks
+- All scores displayed as percentages rounded to 2 decimal places
 
 ## Recommendations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ readme = "README.md"
 python = "^3.10"
 loguru = "^0.7.3"
 datasets = "^3.2.0"
-transformers = {extras = ["torch"], version = "^4.48.2"}
+transformers = {extras = ["torch"], version = "^4.49.0"}
+evaluate = "^0.4.3"
+scikit-learn = "^1.6.1"
+scipy = "^1.15.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/bertdistiller/evaluation/__init__.py
+++ b/src/bertdistiller/evaluation/__init__.py
@@ -1,0 +1,4 @@
+from .evaluation import evaluate
+from .run_glue import DataTrainingArguments, ModelArguments
+
+__all__ = ["evaluate", "DataTrainingArguments", "ModelArguments"]

--- a/src/bertdistiller/evaluation/__init__.py
+++ b/src/bertdistiller/evaluation/__init__.py
@@ -1,4 +1,3 @@
-from .evaluation import evaluate
-from .run_glue import DataTrainingArguments, ModelArguments
+from .evaluation import evaluate, create_summary_table
 
-__all__ = ["evaluate", "DataTrainingArguments", "ModelArguments"]
+__all__ = ["evaluate", "create_summary_table"]

--- a/src/bertdistiller/evaluation/evaluation.py
+++ b/src/bertdistiller/evaluation/evaluation.py
@@ -1,0 +1,171 @@
+import json
+import tempfile
+from dataclasses import asdict
+from itertools import product
+from pathlib import Path
+from typing import List, Optional
+import subprocess
+
+from loguru import logger
+from transformers import TrainingArguments
+
+from .run_glue import DataTrainingArguments, ModelArguments
+
+
+def evaluate(
+    model_name_or_path: str,
+    tasks: List[str] = ["mnli", "qnli", "qqp", "rte", "sst2", "mrpc", "cola", "stsb"],
+    learning_rate: List[float] = [1e-5, 3e-5, 5e-5],
+    epochs: List[int] = [3, 5, 10],
+    output_dir: str = "./evaluation_results",
+    per_device_train_batch_size: int = 32,
+    per_device_eval_batch_size: int = 32,
+    max_seq_length: int = 128,
+    seed: int = 42,
+    model_args: Optional[ModelArguments] = None,
+    data_args: Optional[DataTrainingArguments] = None,
+    training_args: Optional[TrainingArguments] = None,
+    run_glue_script_path: str = "src/bertdistiller/evaluation/run_glue.py",
+    cache_dir: Optional[str] = None,
+    **additional_args,
+) -> None:
+    """
+    Evaluate a model on GLUE tasks with various hyperparameter combinations.
+
+    Args:
+        model_name_or_path: Path to the pretrained model or model identifier from huggingface.co/models
+        tasks: List of GLUE tasks to evaluate on
+        learning_rates: List of learning rates to try
+        epochs: List of number of epochs to try
+        output_dir: Base directory to save evaluation results
+        per_device_train_batch_size: Batch size for training
+        per_device_eval_batch_size: Batch size for evaluation
+        max_seq_length: Maximum sequence length
+        seed: Random seed for reproducibility
+        model_args: Optional ModelArguments to override defaults
+        data_args: Optional DataTrainingArguments to override defaults
+        training_args: Optional TrainingArguments to override defaults
+        run_glue_script_path: Path to the run_glue.py script
+        cache_dir: Directory to cache model and datasets
+        **additional_args: Additional arguments to pass to the script
+    """
+    short_model_name = (
+        model_name_or_path
+        if "/" not in model_name_or_path
+        else model_name_or_path.split("/")[-1]
+    )
+    output_dir = Path(output_dir)
+    output_dir = output_dir / short_model_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # all_results = {}
+
+    # Create parameter grid
+    param_grid = list(product(tasks, learning_rate, epochs))
+    total_runs = len(param_grid)
+
+    logger.info(
+        f"Starting evaluation of model {short_model_name} on {len(tasks)} tasks with {total_runs} parameter combinations"
+    )
+
+    for i, (task, lr, num_epochs) in enumerate(param_grid):
+        logger.info(
+            f"Run {i+1}/{total_runs}: Task: {task}, Learning Rate: {lr}, Epochs: {num_epochs}"
+        )
+
+        task_output_dir = (
+            output_dir / task / f"{num_epochs}_{str(lr).replace('.', '_')}"
+        )
+        task_output_dir.mkdir(parents=True, exist_ok=True)
+
+        model_args_dict = {
+            "model_name_or_path": model_name_or_path,
+            "cache_dir": cache_dir,
+        }
+
+        data_args_dict = {
+            "task_name": task,
+            "max_seq_length": max_seq_length,
+        }
+
+        training_args_dict = {
+            "output_dir": str(task_output_dir),
+            "do_train": True,
+            "do_eval": True,
+            "learning_rate": lr,
+            "num_train_epochs": num_epochs,
+            "per_device_train_batch_size": per_device_train_batch_size,
+            "per_device_eval_batch_size": per_device_eval_batch_size,
+            "warmup_ratio": 0.1,
+            "weight_decay": 0.01,
+            "evaluation_strategy": "epoch",
+            "eval_steps": 1_000_000_000,
+            "save_steps": 1_000_000_000,
+            # "save_strategy": "epoch",
+            # "load_best_model_at_end": True,
+            "seed": seed,
+            "overwrite_output_dir": True,
+        }
+
+        if model_args:
+            for key, value in asdict(model_args).items():
+                if value is not None:
+                    model_args_dict[key] = value
+
+        if data_args:
+            for key, value in asdict(data_args).items():
+                if value is not None:
+                    data_args_dict[key] = value
+
+        if training_args:
+            for key, value in asdict(training_args).items():
+                if value is not None:
+                    training_args_dict[key] = value
+
+        # Create temporary JSON file with all the arguments
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(
+                # {
+                #     "model_args": asdict(default_model_args),
+                #     "data_args": asdict(default_data_args),
+                #     "training_args": asdict(default_training_args),
+                # },
+                {
+                    **model_args_dict,
+                    **data_args_dict,
+                    **training_args_dict,
+                },
+                f,
+                indent=2,
+            )
+            args_file = f.name
+
+        try:
+            # Run the evaluation script
+            cmd = ["python", run_glue_script_path, args_file]
+            logger.info(f"Running command: {' '.join(cmd)}")
+
+            # Run the command
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+            )
+            # Print output in real-time
+            while True:
+                output = process.stdout.readline()
+                if output == "" and process.poll() is not None:
+                    break
+                if output:
+                    print(output.strip(), flush=True)
+
+            # Get return code
+            return_code = process.poll()
+
+            if return_code != 0:
+                logger.error(f"Process exited with code {return_code}")
+
+        finally:
+            # Remove the temporary file
+            Path(args_file).unlink()

--- a/src/bertdistiller/evaluation/run_glue.py
+++ b/src/bertdistiller/evaluation/run_glue.py
@@ -253,22 +253,27 @@ class ModelArguments:
     )
 
 
-def main():
+def run_glue(
+    model_args: ModelArguments = None,
+    data_args: DataTrainingArguments = None,
+    training_args: TrainingArguments = None,
+):
     # See all possible arguments in src/transformers/training_args.py
     # or by passing the --help flag to this script.
     # We now keep distinct sets of args, for a cleaner separation of concerns.
+    if model_args is None and data_args is None and training_args is None:
 
-    parser = HfArgumentParser(
-        (ModelArguments, DataTrainingArguments, TrainingArguments)
-    )
-    if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
-        # If we pass only one argument to the script and it's the path to a json file,
-        # let's parse it to get our arguments.
-        model_args, data_args, training_args = parser.parse_json_file(
-            json_file=os.path.abspath(sys.argv[1])
+        parser = HfArgumentParser(
+            (ModelArguments, DataTrainingArguments, TrainingArguments)
         )
-    else:
-        model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+        if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+            # If we pass only one argument to the script and it's the path to a json file,
+            # let's parse it to get our arguments.
+            model_args, data_args, training_args = parser.parse_json_file(
+                json_file=os.path.abspath(sys.argv[1])
+            )
+        else:
+            model_args, data_args, training_args = parser.parse_args_into_dataclasses()
 
     # Sending telemetry. Tracking the example usage helps us better allocate resources to maintain them. The
     # information sent is the one passed as arguments along with your Python/PyTorch versions.
@@ -744,8 +749,8 @@ def main():
 
 def _mp_fn(index):
     # For xla_spawn (TPUs)
-    main()
+    run_glue()
 
 
 if __name__ == "__main__":
-    main()
+    run_glue()

--- a/src/bertdistiller/evaluation/run_glue.py
+++ b/src/bertdistiller/evaluation/run_glue.py
@@ -1,0 +1,751 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2020 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Finetuning the library models for sequence classification on GLUE."""
+# You can also adapt this script on your own text classification task. Pointers for this are left as comments.
+
+import logging
+import os
+import random
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+import datasets
+import evaluate
+import numpy as np
+from datasets import load_dataset
+
+import transformers
+from transformers import (
+    AutoConfig,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    DataCollatorWithPadding,
+    EvalPrediction,
+    HfArgumentParser,
+    PretrainedConfig,
+    Trainer,
+    TrainingArguments,
+    default_data_collator,
+    set_seed,
+)
+from transformers.trainer_utils import get_last_checkpoint
+from transformers.utils import check_min_version, send_example_telemetry
+from transformers.utils.versions import require_version
+
+
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
+# check_min_version("4.50.0.dev0")
+
+require_version(
+    "datasets>=1.8.0",
+    "To fix: pip install -r examples/pytorch/text-classification/requirements.txt",
+)
+
+task_to_keys = {
+    "cola": ("sentence", None),
+    "mnli": ("premise", "hypothesis"),
+    "mrpc": ("sentence1", "sentence2"),
+    "qnli": ("question", "sentence"),
+    "qqp": ("question1", "question2"),
+    "rte": ("sentence1", "sentence2"),
+    "sst2": ("sentence", None),
+    "stsb": ("sentence1", "sentence2"),
+    "wnli": ("sentence1", "sentence2"),
+}
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DataTrainingArguments:
+    """
+    Arguments pertaining to what data we are going to input our model for training and eval.
+
+    Using `HfArgumentParser` we can turn this class
+    into argparse arguments to be able to specify them on
+    the command line.
+    """
+
+    task_name: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "The name of the task to train on: "
+            + ", ".join(task_to_keys.keys())
+        },
+    )
+    dataset_name: Optional[str] = field(
+        default=None,
+        metadata={"help": "The name of the dataset to use (via the datasets library)."},
+    )
+    dataset_config_name: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "The configuration name of the dataset to use (via the datasets library)."
+        },
+    )
+    max_seq_length: int = field(
+        default=128,
+        metadata={
+            "help": (
+                "The maximum total input sequence length after tokenization. Sequences longer "
+                "than this will be truncated, sequences shorter will be padded."
+            )
+        },
+    )
+    overwrite_cache: bool = field(
+        default=False,
+        metadata={"help": "Overwrite the cached preprocessed datasets or not."},
+    )
+    pad_to_max_length: bool = field(
+        default=True,
+        metadata={
+            "help": (
+                "Whether to pad all samples to `max_seq_length`. "
+                "If False, will pad the samples dynamically when batching to the maximum length in the batch."
+            )
+        },
+    )
+    max_train_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of training examples to this "
+                "value if set."
+            )
+        },
+    )
+    max_eval_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of evaluation examples to this "
+                "value if set."
+            )
+        },
+    )
+    max_predict_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of prediction examples to this "
+                "value if set."
+            )
+        },
+    )
+    train_file: Optional[str] = field(
+        default=None,
+        metadata={"help": "A csv or a json file containing the training data."},
+    )
+    validation_file: Optional[str] = field(
+        default=None,
+        metadata={"help": "A csv or a json file containing the validation data."},
+    )
+    test_file: Optional[str] = field(
+        default=None,
+        metadata={"help": "A csv or a json file containing the test data."},
+    )
+
+    def __post_init__(self):
+        if self.task_name is not None:
+            self.task_name = self.task_name.lower()
+            if self.task_name not in task_to_keys.keys():
+                raise ValueError(
+                    "Unknown task, you should pick one in "
+                    + ",".join(task_to_keys.keys())
+                )
+        elif self.dataset_name is not None:
+            pass
+        elif self.train_file is None or self.validation_file is None:
+            raise ValueError(
+                "Need either a GLUE task, a training/validation file or a dataset name."
+            )
+        else:
+            train_extension = self.train_file.split(".")[-1]
+            assert train_extension in [
+                "csv",
+                "json",
+            ], "`train_file` should be a csv or a json file."
+            validation_extension = self.validation_file.split(".")[-1]
+            assert (
+                validation_extension == train_extension
+            ), "`validation_file` should have the same extension (csv or json) as `train_file`."
+
+
+@dataclass
+class ModelArguments:
+    """
+    Arguments pertaining to which model/config/tokenizer we are going to fine-tune from.
+    """
+
+    model_name_or_path: str = field(
+        metadata={
+            "help": "Path to pretrained model or model identifier from huggingface.co/models"
+        }
+    )
+    config_name: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Pretrained config name or path if not the same as model_name"
+        },
+    )
+    tokenizer_name: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Pretrained tokenizer name or path if not the same as model_name"
+        },
+    )
+    cache_dir: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Where do you want to store the pretrained models downloaded from huggingface.co"
+        },
+    )
+    use_fast_tokenizer: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."
+        },
+    )
+    model_revision: str = field(
+        default="main",
+        metadata={
+            "help": "The specific model version to use (can be a branch name, tag name or commit id)."
+        },
+    )
+    token: str = field(
+        default=None,
+        metadata={
+            "help": (
+                "The token to use as HTTP bearer authorization for remote files. If not specified, will use the token "
+                "generated when running `huggingface-cli login` (stored in `~/.huggingface`)."
+            )
+        },
+    )
+    trust_remote_code: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to trust the execution of code from datasets/models defined on the Hub."
+                " This option should only be set to `True` for repositories you trust and in which you have read the"
+                " code, as it will execute code present on the Hub on your local machine."
+            )
+        },
+    )
+    ignore_mismatched_sizes: bool = field(
+        default=False,
+        metadata={
+            "help": "Will enable to load a pretrained model whose head dimensions are different."
+        },
+    )
+
+
+def main():
+    # See all possible arguments in src/transformers/training_args.py
+    # or by passing the --help flag to this script.
+    # We now keep distinct sets of args, for a cleaner separation of concerns.
+
+    parser = HfArgumentParser(
+        (ModelArguments, DataTrainingArguments, TrainingArguments)
+    )
+    if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+        # If we pass only one argument to the script and it's the path to a json file,
+        # let's parse it to get our arguments.
+        model_args, data_args, training_args = parser.parse_json_file(
+            json_file=os.path.abspath(sys.argv[1])
+        )
+    else:
+        model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+
+    # Sending telemetry. Tracking the example usage helps us better allocate resources to maintain them. The
+    # information sent is the one passed as arguments along with your Python/PyTorch versions.
+    send_example_telemetry("run_glue", model_args, data_args)
+
+    # Setup logging
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+    if training_args.should_log:
+        # The default of training_args.log_level is passive, so we set log level at info here to have that default.
+        transformers.utils.logging.set_verbosity_info()
+
+    log_level = training_args.get_process_log_level()
+    logger.setLevel(log_level)
+    datasets.utils.logging.set_verbosity(log_level)
+    transformers.utils.logging.set_verbosity(log_level)
+    transformers.utils.logging.enable_default_handler()
+    transformers.utils.logging.enable_explicit_format()
+
+    # Log on each process the small summary:
+    logger.warning(
+        f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}, "
+        + f"distributed training: {training_args.parallel_mode.value == 'distributed'}, 16-bits training: {training_args.fp16}"
+    )
+    logger.info(f"Training/evaluation parameters {training_args}")
+
+    # Detecting last checkpoint.
+    last_checkpoint = None
+    if (
+        os.path.isdir(training_args.output_dir)
+        and training_args.do_train
+        and not training_args.overwrite_output_dir
+    ):
+        last_checkpoint = get_last_checkpoint(training_args.output_dir)
+        if last_checkpoint is None and len(os.listdir(training_args.output_dir)) > 0:
+            raise ValueError(
+                f"Output directory ({training_args.output_dir}) already exists and is not empty. "
+                "Use --overwrite_output_dir to overcome."
+            )
+        elif (
+            last_checkpoint is not None and training_args.resume_from_checkpoint is None
+        ):
+            logger.info(
+                f"Checkpoint detected, resuming training at {last_checkpoint}. To avoid this behavior, change "
+                "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
+            )
+
+    # Set seed before initializing model.
+    set_seed(training_args.seed)
+
+    # Get the datasets: you can either provide your own CSV/JSON training and evaluation files (see below)
+    # or specify a GLUE benchmark task (the dataset will be downloaded automatically from the datasets Hub).
+    #
+    # For CSV/JSON files, this script will use as labels the column called 'label' and as pair of sentences the
+    # sentences in columns called 'sentence1' and 'sentence2' if such column exists or the first two columns not named
+    # label if at least two columns are provided.
+    #
+    # If the CSVs/JSONs contain only one non-label column, the script does single sentence classification on this
+    # single column. You can easily tweak this behavior (see below)
+    #
+    # In distributed training, the load_dataset function guarantee that only one local process can concurrently
+    # download the dataset.
+    if data_args.task_name is not None:
+        # Downloading and loading a dataset from the hub.
+        raw_datasets = load_dataset(
+            "nyu-mll/glue",
+            data_args.task_name,
+            cache_dir=model_args.cache_dir,
+            token=model_args.token,
+        )
+    elif data_args.dataset_name is not None:
+        # Downloading and loading a dataset from the hub.
+        raw_datasets = load_dataset(
+            data_args.dataset_name,
+            data_args.dataset_config_name,
+            cache_dir=model_args.cache_dir,
+            token=model_args.token,
+            trust_remote_code=model_args.trust_remote_code,
+        )
+    else:
+        # Loading a dataset from your local files.
+        # CSV/JSON training and evaluation files are needed.
+        data_files = {
+            "train": data_args.train_file,
+            "validation": data_args.validation_file,
+        }
+
+        # Get the test dataset: you can provide your own CSV/JSON test file (see below)
+        # when you use `do_predict` without specifying a GLUE benchmark task.
+        if training_args.do_predict:
+            if data_args.test_file is not None:
+                train_extension = data_args.train_file.split(".")[-1]
+                test_extension = data_args.test_file.split(".")[-1]
+                assert (
+                    test_extension == train_extension
+                ), "`test_file` should have the same extension (csv or json) as `train_file`."
+                data_files["test"] = data_args.test_file
+            else:
+                raise ValueError(
+                    "Need either a GLUE task or a test file for `do_predict`."
+                )
+
+        for key in data_files.keys():
+            logger.info(f"load a local file for {key}: {data_files[key]}")
+
+        if data_args.train_file.endswith(".csv"):
+            # Loading a dataset from local csv files
+            raw_datasets = load_dataset(
+                "csv",
+                data_files=data_files,
+                cache_dir=model_args.cache_dir,
+                token=model_args.token,
+            )
+        else:
+            # Loading a dataset from local json files
+            raw_datasets = load_dataset(
+                "json",
+                data_files=data_files,
+                cache_dir=model_args.cache_dir,
+                token=model_args.token,
+            )
+    # See more about loading any type of standard or custom dataset at
+    # https://huggingface.co/docs/datasets/loading_datasets.
+
+    # Labels
+    if data_args.task_name is not None:
+        is_regression = data_args.task_name == "stsb"
+        if not is_regression:
+            label_list = raw_datasets["train"].features["label"].names
+            num_labels = len(label_list)
+        else:
+            num_labels = 1
+    else:
+        # Trying to have good defaults here, don't hesitate to tweak to your needs.
+        is_regression = raw_datasets["train"].features["label"].dtype in [
+            "float32",
+            "float64",
+        ]
+        if is_regression:
+            num_labels = 1
+        else:
+            # A useful fast method:
+            # https://huggingface.co/docs/datasets/package_reference/main_classes#datasets.Dataset.unique
+            label_list = raw_datasets["train"].unique("label")
+            label_list.sort()  # Let's sort it for determinism
+            num_labels = len(label_list)
+
+    # Load pretrained model and tokenizer
+    #
+    # In distributed training, the .from_pretrained methods guarantee that only one local process can concurrently
+    # download model & vocab.
+    config = AutoConfig.from_pretrained(
+        (
+            model_args.config_name
+            if model_args.config_name
+            else model_args.model_name_or_path
+        ),
+        num_labels=num_labels,
+        finetuning_task=data_args.task_name,
+        cache_dir=model_args.cache_dir,
+        revision=model_args.model_revision,
+        token=model_args.token,
+        trust_remote_code=model_args.trust_remote_code,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(
+        (
+            model_args.tokenizer_name
+            if model_args.tokenizer_name
+            else model_args.model_name_or_path
+        ),
+        cache_dir=model_args.cache_dir,
+        use_fast=model_args.use_fast_tokenizer,
+        revision=model_args.model_revision,
+        token=model_args.token,
+        trust_remote_code=model_args.trust_remote_code,
+    )
+    model = AutoModelForSequenceClassification.from_pretrained(
+        model_args.model_name_or_path,
+        from_tf=bool(".ckpt" in model_args.model_name_or_path),
+        config=config,
+        cache_dir=model_args.cache_dir,
+        revision=model_args.model_revision,
+        token=model_args.token,
+        trust_remote_code=model_args.trust_remote_code,
+        ignore_mismatched_sizes=model_args.ignore_mismatched_sizes,
+    )
+
+    # Preprocessing the raw_datasets
+    if data_args.task_name is not None:
+        sentence1_key, sentence2_key = task_to_keys[data_args.task_name]
+    else:
+        # Again, we try to have some nice defaults but don't hesitate to tweak to your use case.
+        non_label_column_names = [
+            name for name in raw_datasets["train"].column_names if name != "label"
+        ]
+        if (
+            "sentence1" in non_label_column_names
+            and "sentence2" in non_label_column_names
+        ):
+            sentence1_key, sentence2_key = "sentence1", "sentence2"
+        else:
+            if len(non_label_column_names) >= 2:
+                sentence1_key, sentence2_key = non_label_column_names[:2]
+            else:
+                sentence1_key, sentence2_key = non_label_column_names[0], None
+
+    # Padding strategy
+    if data_args.pad_to_max_length:
+        padding = "max_length"
+    else:
+        # We will pad later, dynamically at batch creation, to the max sequence length in each batch
+        padding = False
+
+    # Some models have set the order of the labels to use, so let's make sure we do use it.
+    label_to_id = None
+    if (
+        model.config.label2id != PretrainedConfig(num_labels=num_labels).label2id
+        and data_args.task_name is not None
+        and not is_regression
+    ):
+        # Some have all caps in their config, some don't.
+        label_name_to_id = {k.lower(): v for k, v in model.config.label2id.items()}
+        if sorted(label_name_to_id.keys()) == sorted(label_list):
+            label_to_id = {
+                i: int(label_name_to_id[label_list[i]]) for i in range(num_labels)
+            }
+        else:
+            logger.warning(
+                "Your model seems to have been trained with labels, but they don't match the dataset: "
+                f"model labels: {sorted(label_name_to_id.keys())}, dataset labels: {sorted(label_list)}."
+                "\nIgnoring the model labels as a result.",
+            )
+    elif data_args.task_name is None and not is_regression:
+        label_to_id = {v: i for i, v in enumerate(label_list)}
+
+    if label_to_id is not None:
+        model.config.label2id = label_to_id
+        model.config.id2label = {id: label for label, id in config.label2id.items()}
+    elif data_args.task_name is not None and not is_regression:
+        model.config.label2id = {label: i for i, label in enumerate(label_list)}
+        model.config.id2label = {id: label for label, id in config.label2id.items()}
+
+    if data_args.max_seq_length > tokenizer.model_max_length:
+        logger.warning(
+            f"The max_seq_length passed ({data_args.max_seq_length}) is larger than the maximum length for the "
+            f"model ({tokenizer.model_max_length}). Using max_seq_length={tokenizer.model_max_length}."
+        )
+    max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
+
+    def preprocess_function(examples):
+        # Tokenize the texts
+        args = (
+            (examples[sentence1_key],)
+            if sentence2_key is None
+            else (examples[sentence1_key], examples[sentence2_key])
+        )
+        result = tokenizer(
+            *args, padding=padding, max_length=max_seq_length, truncation=True
+        )
+
+        # Map labels to IDs (not necessary for GLUE tasks)
+        if label_to_id is not None and "label" in examples:
+            result["label"] = [
+                (label_to_id[label] if label != -1 else -1)
+                for label in examples["label"]
+            ]
+        return result
+
+    with training_args.main_process_first(desc="dataset map pre-processing"):
+        raw_datasets = raw_datasets.map(
+            preprocess_function,
+            batched=True,
+            load_from_cache_file=not data_args.overwrite_cache,
+            desc="Running tokenizer on dataset",
+        )
+    if training_args.do_train:
+        if "train" not in raw_datasets:
+            raise ValueError("--do_train requires a train dataset")
+        train_dataset = raw_datasets["train"]
+        if data_args.max_train_samples is not None:
+            max_train_samples = min(len(train_dataset), data_args.max_train_samples)
+            train_dataset = train_dataset.select(range(max_train_samples))
+
+    if training_args.do_eval:
+        if (
+            "validation" not in raw_datasets
+            and "validation_matched" not in raw_datasets
+        ):
+            raise ValueError("--do_eval requires a validation dataset")
+        eval_dataset = raw_datasets[
+            "validation_matched" if data_args.task_name == "mnli" else "validation"
+        ]
+        if data_args.max_eval_samples is not None:
+            max_eval_samples = min(len(eval_dataset), data_args.max_eval_samples)
+            eval_dataset = eval_dataset.select(range(max_eval_samples))
+
+    if (
+        training_args.do_predict
+        or data_args.task_name is not None
+        or data_args.test_file is not None
+    ):
+        if "test" not in raw_datasets and "test_matched" not in raw_datasets:
+            raise ValueError("--do_predict requires a test dataset")
+        predict_dataset = raw_datasets[
+            "test_matched" if data_args.task_name == "mnli" else "test"
+        ]
+        if data_args.max_predict_samples is not None:
+            max_predict_samples = min(
+                len(predict_dataset), data_args.max_predict_samples
+            )
+            predict_dataset = predict_dataset.select(range(max_predict_samples))
+
+    # Log a few random samples from the training set:
+    if training_args.do_train:
+        for index in random.sample(range(len(train_dataset)), 3):
+            logger.info(f"Sample {index} of the training set: {train_dataset[index]}.")
+
+    # Get the metric function
+    if data_args.task_name is not None:
+        metric = evaluate.load(
+            "glue", data_args.task_name, cache_dir=model_args.cache_dir
+        )
+    elif is_regression:
+        metric = evaluate.load("mse", cache_dir=model_args.cache_dir)
+    else:
+        metric = evaluate.load("accuracy", cache_dir=model_args.cache_dir)
+
+    # You can define your custom compute_metrics function. It takes an `EvalPrediction` object (a namedtuple with a
+    # predictions and label_ids field) and has to return a dictionary string to float.
+    def compute_metrics(p: EvalPrediction):
+        preds = p.predictions[0] if isinstance(p.predictions, tuple) else p.predictions
+        preds = np.squeeze(preds) if is_regression else np.argmax(preds, axis=1)
+        result = metric.compute(predictions=preds, references=p.label_ids)
+        if len(result) > 1:
+            result["combined_score"] = np.mean(list(result.values())).item()
+        return result
+
+    # Data collator will default to DataCollatorWithPadding when the tokenizer is passed to Trainer, so we change it if
+    # we already did the padding.
+    if data_args.pad_to_max_length:
+        data_collator = default_data_collator
+    elif training_args.fp16:
+        data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8)
+    else:
+        data_collator = None
+
+    # Initialize our Trainer
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset if training_args.do_train else None,
+        eval_dataset=eval_dataset if training_args.do_eval else None,
+        compute_metrics=compute_metrics,
+        processing_class=tokenizer,
+        data_collator=data_collator,
+    )
+
+    # Training
+    if training_args.do_train:
+        checkpoint = None
+        if training_args.resume_from_checkpoint is not None:
+            checkpoint = training_args.resume_from_checkpoint
+        elif last_checkpoint is not None:
+            checkpoint = last_checkpoint
+        train_result = trainer.train(resume_from_checkpoint=checkpoint)
+        metrics = train_result.metrics
+        max_train_samples = (
+            data_args.max_train_samples
+            if data_args.max_train_samples is not None
+            else len(train_dataset)
+        )
+        metrics["train_samples"] = min(max_train_samples, len(train_dataset))
+
+        trainer.save_model()  # Saves the tokenizer too for easy upload
+
+        trainer.log_metrics("train", metrics)
+        trainer.save_metrics("train", metrics)
+        trainer.save_state()
+
+    # Evaluation
+    if training_args.do_eval:
+        logger.info("*** Evaluate ***")
+
+        # Loop to handle MNLI double evaluation (matched, mis-matched)
+        tasks = [data_args.task_name]
+        eval_datasets = [eval_dataset]
+        if data_args.task_name == "mnli":
+            tasks.append("mnli-mm")
+            valid_mm_dataset = raw_datasets["validation_mismatched"]
+            if data_args.max_eval_samples is not None:
+                max_eval_samples = min(
+                    len(valid_mm_dataset), data_args.max_eval_samples
+                )
+                valid_mm_dataset = valid_mm_dataset.select(range(max_eval_samples))
+            eval_datasets.append(valid_mm_dataset)
+            combined = {}
+
+        for eval_dataset, task in zip(eval_datasets, tasks):
+            metrics = trainer.evaluate(eval_dataset=eval_dataset)
+
+            max_eval_samples = (
+                data_args.max_eval_samples
+                if data_args.max_eval_samples is not None
+                else len(eval_dataset)
+            )
+            metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
+
+            if task == "mnli-mm":
+                metrics = {k + "_mm": v for k, v in metrics.items()}
+            if task is not None and "mnli" in task:
+                combined.update(metrics)
+
+            trainer.log_metrics("eval", metrics)
+            trainer.save_metrics(
+                "eval", combined if task is not None and "mnli" in task else metrics
+            )
+
+    if training_args.do_predict:
+        logger.info("*** Predict ***")
+
+        # Loop to handle MNLI double evaluation (matched, mis-matched)
+        tasks = [data_args.task_name]
+        predict_datasets = [predict_dataset]
+        if data_args.task_name == "mnli":
+            tasks.append("mnli-mm")
+            predict_datasets.append(raw_datasets["test_mismatched"])
+
+        for predict_dataset, task in zip(predict_datasets, tasks):
+            # Removing the `label` columns because it contains -1 and Trainer won't like that.
+            predict_dataset = predict_dataset.remove_columns("label")
+            predictions = trainer.predict(
+                predict_dataset, metric_key_prefix="predict"
+            ).predictions
+            predictions = (
+                np.squeeze(predictions)
+                if is_regression
+                else np.argmax(predictions, axis=1)
+            )
+
+            output_predict_file = os.path.join(
+                training_args.output_dir, f"predict_results_{task}.txt"
+            )
+            if trainer.is_world_process_zero():
+                with open(output_predict_file, "w") as writer:
+                    logger.info(f"***** Predict results {task} *****")
+                    writer.write("index\tprediction\n")
+                    for index, item in enumerate(predictions):
+                        if is_regression:
+                            writer.write(f"{index}\t{item:3.3f}\n")
+                        else:
+                            item = label_list[item]
+                            writer.write(f"{index}\t{item}\n")
+
+    kwargs = {
+        "finetuned_from": model_args.model_name_or_path,
+        "tasks": "text-classification",
+    }
+    if data_args.task_name is not None:
+        kwargs["language"] = "en"
+        kwargs["dataset_tags"] = "glue"
+        kwargs["dataset_args"] = data_args.task_name
+        kwargs["dataset"] = f"GLUE {data_args.task_name.upper()}"
+
+    if training_args.push_to_hub:
+        trainer.push_to_hub(**kwargs)
+    else:
+        trainer.create_model_card(**kwargs)
+
+
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## GLUE Evaluation
Add evaluation on GLUE tasks for task agnostic distillation. The evaluation follows the original implementation from [Hugging Face Transformers examples](https://github.com/huggingface/transformers/blob/main/examples/pytorch/text-classification/run_glue.py) with minor changes to fit into the library structure.

- Add and adapt the ' run_glue.py` script from Hugging Face Transformers Examples
- Create `evaluate` that wraps and calls the glue evaluation on multiple tasks with different hyperparameters
- Create `create_summary_table` method for model evaluation results summary generation
- Update README with evaluation and create summary